### PR TITLE
Call extract_entities() with 4 concurrent jobs

### DIFF
--- a/entities.ipynb
+++ b/entities.ipynb
@@ -16,7 +16,6 @@
     "from tqdm import tqdm\n",
     "\n",
     "from helpers.logging import OutputWidgetHandler\n",
-    "from libratom.cli.subcommands import entities\n",
     "from libratom.lib.database import db_session\n",
     "from libratom.lib.entities import (\n",
     "    OUTPUT_FILENAME_TEMPLATE,\n",
@@ -33,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "logger = logging.getLogger(__name__)\n",
+    "logger = logging.getLogger()\n",
     "handler = OutputWidgetHandler()\n",
     "handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT))\n",
     "logger.addHandler(handler)\n",
@@ -141,6 +140,7 @@
     "            files=files,\n",
     "            destination=out,\n",
     "            spacy_model=spacy_model,\n",
+    "            jobs=4,\n",
     "            progress_callback=msg_bar.update,\n",
     "        )\n"
    ]


### PR DESCRIPTION
This seems to allow the extraction to complete on mybinder.org. We can dig further if we want to...
Also a small logging fix (Jupyter sets a root logger so that's what needs to be configured, not the module logger).